### PR TITLE
Fix cube creation loops to restore class methods

### DIFF
--- a/cube.js
+++ b/cube.js
@@ -57,12 +57,14 @@ export class Cube {
           this.cubies.push(mesh);
         }
       }
+    }
+  }
+
   update(dt){
     if(this.isAnimating) this._animate(dt);
     else if(!this.paused) this._next();
     this.controls.update();
     this.renderer.render(this.scene,this.camera);
-  }
   }
 
   play(){this.paused=false;}


### PR DESCRIPTION
## Summary
- close nested loops in `_createCubies` and end the method before `update`
- ensure subsequent class methods (`update`, `play`, etc.) are declared at the class level

## Testing
- `node --check cube.js`
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b9fef25ec8321b3c9ca0a27880066